### PR TITLE
Fixed seiersrekke errors

### DIFF
--- a/src/components/panels/Infos.tsx
+++ b/src/components/panels/Infos.tsx
@@ -378,7 +378,7 @@ export function Infos({ isOpen, close }: InfosProps) {
                     <CustomLink href="https://github.com/picosmos">
                       Tom (picosmos)
                     </CustomLink>
-                    , for å fikse noen logisk feil.
+                    , for å fikse noen logiske feil.
                   </>
                 }
               />

--- a/src/components/panels/Infos.tsx
+++ b/src/components/panels/Infos.tsx
@@ -372,6 +372,16 @@ export function Infos({ isOpen, close }: InfosProps) {
                   </>
                 }
               />
+              <FAQitemAnswerline
+                text={
+                  <>
+                    <CustomLink href="https://github.com/picosmos">
+                      Tom (picosmos)
+                    </CustomLink>
+                    , for å fikse noen logisk feil.
+                  </>
+                }
+              />
             </>
           }
         />

--- a/src/domain/stats.ts
+++ b/src/domain/stats.ts
@@ -31,7 +31,7 @@ export function getStatsData(): StatsData {
   let bestDistanceSum = 0;
   for (const [dayStringNew, guesses] of allGuessesEntries) {
     bestDistanceSum += Math.min(...guesses.map((guess) => guess.distance));
-    const currentDate = DateTime.fromFormat(dayStringNew, "dd-MM-yyyy");
+    const currentDate = DateTime.fromFormat(dayStringNew, "yyyy-MM-dd");
     const winIndex = guesses.findIndex((guess) => guess.distance === 0);
     const won = winIndex >= 0;
     if (won) {
@@ -54,6 +54,12 @@ export function getStatsData(): StatsData {
       maxStreak = currentStreak;
     }
     previousDate = currentDate;
+  }
+
+  if(previousDate != null && 
+    !previousDate?.plus({ days: 1 }).hasSame(DateTime.now(), "day") && 
+    !previousDate?.hasSame(DateTime.now(), "day")) {
+      currentStreak = 0;
   }
 
   const winCount = Object.values(guessDistribution).reduce(

--- a/src/hooks/useGuesses.ts
+++ b/src/hooks/useGuesses.ts
@@ -37,7 +37,7 @@ class GuessStorage {
   }
 
   static updateGameResults(dayString: string, gameResult: GameResult) {
-    const allGameResults = this.loadAllGuesses();
+    const allGameResults = this.loadAllGameResults();
     localStorage.setItem(
         "gameResult",
         JSON.stringify({


### PR DESCRIPTION
- fixed `GuessStorage.updateGameResults`, even though it caused no problems yet
- date format was incorrect while loading historic guesses, causing the incorrect display
- reset "Nåværende seiersrekke" to 0 if the last game was played before yesterday, (because it cannot be continued)
- Added myself to the thank-you list